### PR TITLE
add filter for s3 dir suffix

### DIFF
--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/s3/PrestoS3FileSystem.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/s3/PrestoS3FileSystem.java
@@ -561,6 +561,7 @@ public class PrestoS3FileSystem
         // user metadata, and in this case it doesn't matter.
         return objects.stream()
                 .filter(object -> !object.getKey().endsWith(PATH_SEPARATOR))
+                .filter(object -> !object.getKey().endsWith(DIRECTORY_SUFFIX))
                 .filter(object -> !skipGlacierObjects || !isGlacierObject(object))
                 .map(object -> new FileStatus(
                         object.getSize(),


### PR DESCRIPTION
Suffix _$folder$ 스캔 배제 추가

- Presto 에서 S3 Object Scan시에 해당 Suffix를 가진 Object에서 오류 발생
- 원인 - AWS EMR Hive에서 Partition Writer가 S3에 파티션 경로를 선점하기 위해 위와 같은 Suffix를 포함한 Path를 생성
- 해결 - Presto의 S3 List Operation에서 해당 Suffix를 가진 객체 배제